### PR TITLE
feat: support for maintenance window config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,11 +36,12 @@ terraform-provider-cleura
 gardener.auto.tfvars
 .terraform.lock.hcl
 __debug_bin*
+*.disabled
 
 
 # Test exclusions
 !command/test-fixtures/**/*.tfstate
 !command/test-fixtures/**/.terraform/
-
+!internal/provider/testdata/TestAccShootResource/*/main.tf
 # Keep windows files with windows line endings
 *.winfile eol=crlf

--- a/docs/resources/shoot_cluster.md
+++ b/docs/resources/shoot_cluster.md
@@ -63,6 +63,7 @@ output "cluster" {
 - `gardener_domain` (String) Gardener domain. Defaults to 'public'
 - `hibernation_schedules` (Attributes List) An array containing desired hibernation schedules (see [below for nested schema](#nestedatt--hibernation_schedules))
 - `kubernetes_version` (String) One of the currently available Kubernetes versions
+- `maintenance` (Attributes) Configure maintenance properties (see [below for nested schema](#nestedatt--maintenance))
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))
 
 ### Read-Only
@@ -121,6 +122,17 @@ Optional:
 
 - `end` (String) The time when the hibernation should end in Cron time format
 - `start` (String) The time when the hibernation should start in Cron time format
+
+
+<a id="nestedatt--maintenance"></a>
+### Nested Schema for `maintenance`
+
+Optional:
+
+- `auto_update_kubernetes` (Boolean) Toggle wether or not to allow automatic kubernetes upgrades. Defaults to 'true'
+- `auto_update_machine_image` (Boolean) Toggle wether or not to allow automatic machine image upgrades. Defaults to 'true'
+- `time_window_begin` (String) Set when time windows for upgrades should begin, defaults to '000000+0100'
+- `time_window_end` (String) Set when time windows for upgrades should end, defaults to '010000+0100'
 
 
 <a id="nestedatt--timeouts"></a>

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,10 @@ module github.com/aztekas/terraform-provider-cleura
 
 go 1.24.3
 
+replace github.com/aztekas/cleura-client-go => /Users/ludwighansson/repos/github/cleura-client-go
+
 require (
-	github.com/aztekas/cleura-client-go v0.0.12
+	github.com/aztekas/cleura-client-go v0.0.13
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/hashicorp/go-version v1.7.0
 	github.com/hashicorp/terraform-plugin-docs v0.21.0

--- a/go.mod
+++ b/go.mod
@@ -2,10 +2,8 @@ module github.com/aztekas/terraform-provider-cleura
 
 go 1.24.3
 
-replace github.com/aztekas/cleura-client-go => /Users/ludwighansson/repos/github/cleura-client-go
-
 require (
-	github.com/aztekas/cleura-client-go v0.0.13
+	github.com/aztekas/cleura-client-go v0.0.14
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/hashicorp/go-version v1.7.0
 	github.com/hashicorp/terraform-plugin-docs v0.21.0

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,8 @@ github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
 github.com/armon/go-radix v1.0.0 h1:F4z6KzEeeQIMeLFa97iZU6vupzoecKdU5TX24SNppXI=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
-github.com/aztekas/cleura-client-go v0.0.13 h1:u5fM2peaM8xrJzn3LxpqN65F0I/MlSkZv5W1D0hkdOU=
-github.com/aztekas/cleura-client-go v0.0.13/go.mod h1:9Q8pYwE3S4Wn6rgcmTgqybrWIDfOQXTTU3LiBuUPZgQ=
+github.com/aztekas/cleura-client-go v0.0.14 h1:bjs7d1xS4MHHK7Op9rFHyhRgYKh5/Q/KMi+O+irS5WA=
+github.com/aztekas/cleura-client-go v0.0.14/go.mod h1:9Q8pYwE3S4Wn6rgcmTgqybrWIDfOQXTTU3LiBuUPZgQ=
 github.com/bgentry/speakeasy v0.1.0 h1:ByYyxL9InA1OWqxJqqp2A5pYHUrCiAL6K3J+LKSsQkY=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bmatcuk/doublestar/v4 v4.8.1 h1:54Bopc5c2cAvhLRAzqOGCYHYyhcDHsFF4wWIR5wKP38=

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,8 @@ github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
 github.com/armon/go-radix v1.0.0 h1:F4z6KzEeeQIMeLFa97iZU6vupzoecKdU5TX24SNppXI=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
-github.com/aztekas/cleura-client-go v0.0.12 h1:tAH1wVK/eezOXhfHwTg7K63eKQfjo8+SyhQ1dhFpXO4=
-github.com/aztekas/cleura-client-go v0.0.12/go.mod h1:9Q8pYwE3S4Wn6rgcmTgqybrWIDfOQXTTU3LiBuUPZgQ=
+github.com/aztekas/cleura-client-go v0.0.13 h1:u5fM2peaM8xrJzn3LxpqN65F0I/MlSkZv5W1D0hkdOU=
+github.com/aztekas/cleura-client-go v0.0.13/go.mod h1:9Q8pYwE3S4Wn6rgcmTgqybrWIDfOQXTTU3LiBuUPZgQ=
 github.com/bgentry/speakeasy v0.1.0 h1:ByYyxL9InA1OWqxJqqp2A5pYHUrCiAL6K3J+LKSsQkY=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bmatcuk/doublestar/v4 v4.8.1 h1:54Bopc5c2cAvhLRAzqOGCYHYyhcDHsFF4wWIR5wKP38=

--- a/internal/provider/shootcluster_resource_test.go
+++ b/internal/provider/shootcluster_resource_test.go
@@ -29,7 +29,6 @@ func TestAccShootResource(t *testing.T) {
 					// resource.TestCheckResourceAttr("cleura_shoot_cluster.test", "kubernetes_version", "1.32.4"),
 					// Verify first worker group in list
 					resource.TestCheckResourceAttr("cleura_shoot_cluster.test", "provider_details.worker_groups.0.image_name", "gardenlinux"),
-					// resource.TestCheckResourceAttr("cleura_shoot_cluster.test", "provider_details.worker_groups.0.image_version", "1592.9.0"),
 					resource.TestCheckResourceAttr("cleura_shoot_cluster.test", "provider_details.worker_groups.0.machine_type", "b.2c4gb"),
 					resource.TestCheckResourceAttr("cleura_shoot_cluster.test", "provider_details.worker_groups.0.max_nodes", "2"),
 					resource.TestCheckResourceAttr("cleura_shoot_cluster.test", "provider_details.worker_groups.0.min_nodes", "1"),
@@ -37,7 +36,7 @@ func TestAccShootResource(t *testing.T) {
 					resource.TestCheckResourceAttr("cleura_shoot_cluster.test", "provider_details.worker_groups.0.worker_node_volume_size", "50Gi"),
 
 					// Verify dynamic values have any value set in the state.
-					// resource.TestCheckResourceAttrSet("cleura_shoot_cluster.test", "uid"), # 2025-05-18: Bug in API, does not return uid in response
+					resource.TestCheckResourceAttrSet("cleura_shoot_cluster.test", "uid"),
 					resource.TestCheckResourceAttrSet("cleura_shoot_cluster.test", "last_updated"),
 					resource.TestCheckResourceAttrSet("cleura_shoot_cluster.test", "hibernated"),
 
@@ -49,6 +48,12 @@ func TestAccShootResource(t *testing.T) {
 					resource.TestCheckResourceAttr("cleura_shoot_cluster.test", "provider_details.worker_groups.0.taints.#", "1"),
 					resource.TestCheckResourceAttr("cleura_shoot_cluster.test", "provider_details.worker_groups.0.zones.#", "1"),
 					resource.TestCheckResourceAttr("cleura_shoot_cluster.test", "provider_details.worker_groups.0.zones.0", "nova"),
+
+					// Verify maintenance configuration
+					resource.TestCheckResourceAttr("cleura_shoot_cluster.test", "maintenance.auto_update_kubernetes", "true"),     // Default value, not set in config
+					resource.TestCheckResourceAttr("cleura_shoot_cluster.test", "maintenance.auto_update_machine_image", "false"), // Manually set in main.tf
+					resource.TestCheckResourceAttr("cleura_shoot_cluster.test", "maintenance.time_window_begin", "050000+0100"),
+					resource.TestCheckResourceAttr("cleura_shoot_cluster.test", "maintenance.time_window_end", "060000+0100"),
 				),
 			},
 			// Update and Read testing
@@ -62,6 +67,51 @@ func TestAccShootResource(t *testing.T) {
 					// Verify fields has been removed
 					resource.TestCheckNoResourceAttr("cleura_shoot_cluster.test", "provider_details.worker_groups.0.annotations.test"),
 					resource.TestCheckNoResourceAttr("cleura_shoot_cluster.test", "provider_details.worker_groups.0.labels.tftestlabel"),
+
+					// Check the second worker group exists and properties are set
+					resource.TestCheckResourceAttr("cleura_shoot_cluster.test", "provider_details.worker_groups.1.worker_group_name", "newwg"),
+					resource.TestCheckResourceAttr("cleura_shoot_cluster.test", "provider_details.worker_groups.1.annotations.annotatontest", "annotationtestvalue"),
+					resource.TestCheckResourceAttr("cleura_shoot_cluster.test", "provider_details.worker_groups.1.labels.labeltest", "labeltestvalue"),
+					// resource.TestCheckResourceAttr("cleura_shoot_cluster.test", "provider_details.worker_groups.1.taints.#", "1"),
+					// resource.TestCheckResourceAttr("cleura_shoot_cluster.test", "provider_details.worker_groups.1.taints.0.key", "taittest"),
+					// resource.TestCheckResourceAttr("cleura_shoot_cluster.test", "provider_details.worker_groups.1.taints.0.value", "tainttestvalue"),
+					// resource.TestCheckResourceAttr("cleura_shoot_cluster.test", "provider_details.worker_groups.1.taints.0.effect", "NoSchedule"),
+					resource.TestCheckResourceAttr("cleura_shoot_cluster.test", "provider_details.worker_groups.1.zones.#", "1"),
+					resource.TestCheckResourceAttr("cleura_shoot_cluster.test", "provider_details.worker_groups.1.zones.0", "nova"),
+
+					// Verify updated maintenance config
+					resource.TestCheckResourceAttr("cleura_shoot_cluster.test", "maintenance.auto_update_kubernetes", "false"),
+					resource.TestCheckResourceAttr("cleura_shoot_cluster.test", "maintenance.auto_update_machine_image", "false"),
+					resource.TestCheckResourceAttr("cleura_shoot_cluster.test", "maintenance.time_window_begin", "020000+0100"),
+					resource.TestCheckResourceAttr("cleura_shoot_cluster.test", "maintenance.time_window_end", "030000+0100"),
+
+					// Verify maintenance config was added
+					resource.TestCheckResourceAttr("cleura_shoot_cluster.test", "hibernation_schedules.#", "1"),
+					resource.TestCheckResourceAttr("cleura_shoot_cluster.test", "hibernation_schedules.0.start", "00 18 * * 1,2,3,4,5"),
+					resource.TestCheckResourceAttr("cleura_shoot_cluster.test", "hibernation_schedules.0.end", "00 08 * * 1,2,3,4,5"),
+				),
+			},
+			{
+				ConfigDirectory: config.TestStepDirectory(),
+				ConfigVariables: varsTest,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("cleura_shoot_cluster.test", "provider_details.worker_groups.0.annotations.annotationsetfromupdate", "defg"),
+					resource.TestCheckResourceAttr("cleura_shoot_cluster.test", "provider_details.worker_groups.0.labels.labelsetfromupdate", "hijk"),
+					resource.TestCheckResourceAttr("cleura_shoot_cluster.test", "provider_details.worker_groups.0.taints.#", "1"),
+					resource.TestCheckResourceAttr("cleura_shoot_cluster.test", "provider_details.worker_groups.0.taints.0.key", "taintsetfromupdate"),
+					resource.TestCheckResourceAttr("cleura_shoot_cluster.test", "provider_details.worker_groups.0.taints.0.value", "789"),
+					resource.TestCheckResourceAttr("cleura_shoot_cluster.test", "provider_details.worker_groups.0.taints.0.effect", "NoSchedule"),
+					resource.TestCheckResourceAttr("cleura_shoot_cluster.test", "provider_details.worker_groups.0.zones.#", "1"),
+					resource.TestCheckResourceAttr("cleura_shoot_cluster.test", "provider_details.worker_groups.0.zones.0", "nova"),
+
+					// Verify only one worker group exists
+					resource.TestCheckResourceAttr("cleura_shoot_cluster.test", "provider_details.worker_groups.#", "1"),
+
+					// Verify maintenance config has reverted to default
+					resource.TestCheckResourceAttr("cleura_shoot_cluster.test", "maintenance.auto_update_kubernetes", "true"),
+					resource.TestCheckResourceAttr("cleura_shoot_cluster.test", "maintenance.auto_update_machine_image", "true"),
+					resource.TestCheckResourceAttr("cleura_shoot_cluster.test", "maintenance.time_window_begin", "000000+0100"),
+					resource.TestCheckResourceAttr("cleura_shoot_cluster.test", "maintenance.time_window_end", "010000+0100"),
 				),
 			},
 			// Delete testing automatically occurs in TestCase

--- a/internal/provider/testdata/TestAccShootResource/1/main.tf
+++ b/internal/provider/testdata/TestAccShootResource/1/main.tf
@@ -1,3 +1,10 @@
+# STEP 1:
+# Creates shoot cluster managing one worker group, with:
+#   * Annotations
+#   * Labels
+#   * Taints
+#   * Zones
+# Set maintenance configuration with custom window times and machine image config to false
 
 resource "cleura_shoot_cluster" "test" {
   project = var.project-id
@@ -27,6 +34,11 @@ resource "cleura_shoot_cluster" "test" {
         ]
       },
     ]
+  }
+  maintenance = {
+    auto_update_machine_image = false
+    time_window_begin = "050000+0100"
+    time_window_end = "060000+0100"
   }
 }
 

--- a/internal/provider/testdata/TestAccShootResource/2/main.tf
+++ b/internal/provider/testdata/TestAccShootResource/2/main.tf
@@ -1,3 +1,8 @@
+# STEP 2:
+# Removes existing annotations, labels, taints and zone config from workergroup
+# Adds a new worker group "newwg" to shoot cluster
+# Modifies values of maintenance configuration block
+
 resource "cleura_shoot_cluster" "test" {
   project = var.project-id
   region = "sto2"
@@ -10,13 +15,40 @@ resource "cleura_shoot_cluster" "test" {
         min_nodes = 1
         max_nodes = 3
       },
-    ]
-    hibernation_schedules = [
+      # add new worker group
       {
-        start = "00 18 * * 1,2,3,4,5"
-        end   = "00 08 * * 1,2,3,4,5"
+        worker_group_name = "newwg"
+        machine_type = "b.2c4gb"
+        min_nodes = 1
+        max_nodes = 1
+        annotations = {
+          "annotatontest": "annotationtestvalue"
+        }
+        labels = {
+          "labeltest": "labeltestvalue"
+        }
+        # taints = [{
+        #   key = "tainttest"
+        #   value = "tainttestvalue"
+        #   effect = "NoSchedule"
+        # }]
+        zones = [
+          "nova"
+        ]
       },
     ]
+  }
+  hibernation_schedules = [
+    {
+      start = "00 18 * * 1,2,3,4,5"
+      end   = "00 08 * * 1,2,3,4,5"
+    },
+  ]
+  maintenance = {
+    auto_update_kubernetes = false
+    auto_update_machine_image = false
+    time_window_begin = "020000+0100"
+    time_window_end = "030000+0100"
   }
 }
 

--- a/internal/provider/testdata/TestAccShootResource/3/main.tf
+++ b/internal/provider/testdata/TestAccShootResource/3/main.tf
@@ -1,0 +1,44 @@
+# STEP 2:
+# Adds annotations, labels, taints and zones back to workergroup (using update function)
+# Removes worker group "newwg" from shoot cluster
+# Removes maintenance configuration
+
+resource "cleura_shoot_cluster" "test" {
+  project = var.project-id
+  region = "sto2"
+  name = "cleuratf-new"
+  provider_details = {
+    worker_groups = [
+	    {
+        worker_group_name = "tstwg"
+        machine_type = "b.2c4gb"
+        min_nodes = 1
+        max_nodes = 3
+        annotations = {
+          "annotationsetfromupdate": "defg",
+        }
+        labels = {
+          "labelsetfromupdate": "hijk"
+        }
+        taints = [{
+          key    = "taintsetfromupdate"
+          value  = "789"
+          effect = "NoSchedule"
+        }]
+        zones = [
+          "nova"
+        ]
+      },
+    ]
+  }
+  hibernation_schedules = [
+    {
+      start = "00 18 * * 1,2,3,4,5"
+      end   = "00 08 * * 1,2,3,4,5"
+    },
+  ]
+}
+
+// Set via CLEURA_TEST_PROJECT_ID environment variable in test suite
+variable "project-id" {
+}


### PR DESCRIPTION
This PR adds support for configuring maintenance properties, like time window when to perform upgrades, as well as what components are allowed to be upgraded. This originated from PR https://github.com/aztekas/terraform-provider-cleura/issues/3.

It also contains some bugfixes and increased reliability when modifying multiple resources in one shoot cluster at once, like adding one worker group while renaming an existing one.

The tests has been extended with further checks and validation for taints, workergroups, labels maintenance windows and annotations, which it passes.

Example configuration using the new `maintenance` block:

```hcl
resource "cleura_shoot_cluster" "test" {
  project = "<project id>"
  region = "sto2"
  name = "example-shoot"
  provider_details = {
    worker_groups = [
      {
        worker_group_name = "tstwg"
        machine_type = "b.2c4gb"
        min_nodes = 1
        max_nodes = 3
      },
    ]
  }
  maintenance = {
    auto_update_kubernetes = false
    auto_update_machine_image = false
    time_window_begin = "020000+0100"
    time_window_end = "030000+0100"
  }
}
```