### PR TITLE
feat: add renew_before option to kubeconfig resource

### DIFF
--- a/docs/resources/shoot_kubeconfig.md
+++ b/docs/resources/shoot_kubeconfig.md
@@ -25,6 +25,7 @@ description: |-
 ### Optional
 
 - `gardener_domain` (String) Gardener domain. Defaults to 'public'
+- `renew_before` (Number) Renew kubeconfig N seconds before expiry. Defaults to 300 (5 min)
 
 ### Read-Only
 


### PR DESCRIPTION
Adds an option to trigger renewal of kubeconfg before it expires. Also implements a validation for worker group naming. 